### PR TITLE
Fix the the inconsistence of the y-axis title

### DIFF
--- a/lib/Meth/BisNonConvRate.R
+++ b/lib/Meth/BisNonConvRate.R
@@ -23,7 +23,7 @@ library(ggplot2)
 #library(reshape2)
 #tab <- melt(tab, id.vars="Sample")
 
-p <- ggplot(tab, aes(x=Sample, y=BisNonConvRate, fill=Sample)) +
+p <- ggplot(tab, aes(x=Sample, y=C_number/Total_Depth*100, fill=Sample)) +
            geom_bar(stat="identity",position="dodge") +
            facet_wrap("Context") +
            theme(axis.text.x=element_text(angle=45, hjust=1)) +


### PR DESCRIPTION
The y-axis title is "Non conversion rate (%)", which indicates that the data were percentage. However, the calculation of "BisNonConvRate" (See: https://github.com/xie186/ViewBS/blob/eb54dfdb45bfc90441ec86a3b6d3dcefac64544d/lib/Meth/BisNonConvRate.pm#L85) was ratio (C_number / Total_Depth), rather than percentage (C_number / Total_Depth*100). Therefore, here we could calculate the percentage of "BisNonConvRate" on the fly.