### PR TITLE
Update GlobalLev.pm: line breaks in the array @context

### DIFF
--- a/lib/Meth/GlobalLev.pm
+++ b/lib/Meth/GlobalLev.pm
@@ -73,7 +73,7 @@ sub generTab{
 
     open OUT, "+>$opts_sub->{outdir}/$opts_sub->{prefix}.tab" or die "$!";
     my @context = sort keys %rec_meth_context;
-    
+    for(@context){chomp $_};
     print OUT "Sample\t", join("\t", @context), "\n";
     ## keys %rec_meth ====> @sample_list 
     ## because we want to keep the order of the input samples


### PR DESCRIPTION
The presence of line breaks in the array @context may result in subsequent drawing errors. The addition of a line break processing step will not affect existing processes, but will effectively resolve the related issue and enhance the overall program robustness.